### PR TITLE
Update copyright info and location 

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,6 +1,6 @@
 Common OVF Tool (COT)
 
-Copyright (c) 2013-2019 by the following developers:
+The following developers have contributed to this project:
 Glenn F. Matthews
 Kevin A. Keim
 Quol Fontana

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -230,7 +230,7 @@ Add yourself as a contributor
 -----------------------------
 
 If you haven't contributed to COT previously, be sure to add yourself as a
-contributor in the ``COPYRIGHT.txt`` file.
+contributor in the ``AUTHORS.txt`` file.
 
 Open a pull request
 -------------------

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2019 the COT project developers.
-See the COPYRIGHT.txt file at the top-level directory of this distribution and
-at https://github.com/glennmatthews/cot/blob/master/COPYRIGHT.txt
+Copyright (c) 2013-2019 Cisco Systems, Inc. and/or its affiliates
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Change copyright owner in LICENSE.txt, and convert COPYRIGHT.txt into AUTHORS.txt, including removing the duplicate copyright info. This enables GitHub to now recognize the license as MIT instead of Other. Update CONTRIBUTING.rst to point to new contributors to AUTHORS.txt.