### PR TITLE
Update nexus 9000v minimum memory

### DIFF
--- a/COT/platforms/cisco_nexus_9000v.py
+++ b/COT/platforms/cisco_nexus_9000v.py
@@ -31,7 +31,7 @@ class Nexus9000v(Platform):
 
     HARDWARE_LIMITS = Platform.HARDWARE_LIMITS.copy()
     HARDWARE_LIMITS.update({
-        Hardware.cpus: ValidRange(1, 4),
+        Hardware.cpus: ValidRange(2, 4),
         Hardware.memory: ValidRange(6144, None),
         Hardware.nic_count: ValidRange(1, 65),
         Hardware.serial_count: ValidRange(1, 1),

--- a/COT/platforms/cisco_nexus_9000v.py
+++ b/COT/platforms/cisco_nexus_9000v.py
@@ -32,7 +32,7 @@ class Nexus9000v(Platform):
     HARDWARE_LIMITS = Platform.HARDWARE_LIMITS.copy()
     HARDWARE_LIMITS.update({
         Hardware.cpus: ValidRange(1, 4),
-        Hardware.memory: ValidRange(8192, None),
+        Hardware.memory: ValidRange(6144, None),
         Hardware.nic_count: ValidRange(1, 65),
         Hardware.serial_count: ValidRange(1, 1),
     })

--- a/COT/platforms/tests/test_cisco_nexus_9000v.py
+++ b/COT/platforms/tests/test_cisco_nexus_9000v.py
@@ -40,8 +40,8 @@ class TestNexus9000v(PlatformTests.PlatformTest):
 
     def test_cpu_count(self):
         """Test CPU count limits."""
-        self.assertRaises(ValueTooLowError, self.ins.validate_cpu_count, 0)
-        self.ins.validate_cpu_count(1)
+        self.assertRaises(ValueTooLowError, self.ins.validate_cpu_count, 1)
+        self.ins.validate_cpu_count(2)
         self.ins.validate_cpu_count(4)
         self.assertRaises(ValueTooHighError, self.ins.validate_cpu_count, 5)
 

--- a/COT/platforms/tests/test_cisco_nexus_9000v.py
+++ b/COT/platforms/tests/test_cisco_nexus_9000v.py
@@ -48,8 +48,8 @@ class TestNexus9000v(PlatformTests.PlatformTest):
     def test_memory_amount(self):
         """Test RAM allocation limits."""
         self.assertRaises(ValueTooLowError,
-                          self.ins.validate_memory_amount, 8191)
-        self.ins.validate_memory_amount(8192)
+                          self.ins.validate_memory_amount, 6143)
+        self.ins.validate_memory_amount(6144)
         self.ins.validate_memory_amount(16384)
         # No upper bound known at present
 


### PR DESCRIPTION
The latest nexus 9000v lite image has reduced the minimum memory to 6GB.